### PR TITLE
Trim off the port number.

### DIFF
--- a/http/http.go
+++ b/http/http.go
@@ -231,7 +231,7 @@ func (s *Server) DefaultHandler(w http.ResponseWriter, r *http.Request) *appErro
 		Port         bool
 	}{
 		response,
-		r.Host,
+		strings.Split(r.Host, ":")[0],
 		response.Latitude + 0.05,
 		response.Latitude - 0.05,
 		response.Longitude - 0.05,


### PR DESCRIPTION
Load balancers may change the incoming "host" header to add a port number.  We just remove it.  It would be cleaner to look for a trusted header that defines the X-Forwarded-Host value, but that would take a lot more changes to code.